### PR TITLE
20241004

### DIFF
--- a/bin/create-signed-jwt.sh
+++ b/bin/create-signed-jwt.sh
@@ -42,9 +42,9 @@ read -r -d '' jwt_payload << EOM
   "iss": "issuer",
   "sub": "subject",
   "aud": "audience",
-  "exp": 1893456000,
-  "nbf": 1664710022,
-  "iat": 1664710022,
+  "exp": 1893456000,                    # "exp": January 1, 2030, 00:00:00 UTC (expiration time)
+  "nbf": 1664710022,                    # "nbf": October 2, 2022, 11:27:02 UTC (not before time)
+  "iat": 1664710022,                    # "iat": October 2, 2022, 11:27:02 UTC (issued at time)
   "jti": "id123456"
 }
 EOM

--- a/bin/create-signed-jwt.sh
+++ b/bin/create-signed-jwt.sh
@@ -24,6 +24,18 @@ NO_COLOR='\033[0m' # No color
 # iat: Issued At - Identifies the time at which the JWT was issued
 # jti: JWT ID - Provides a unique identifier for the JWT
 
+# To make the JWT below a valid OIDC ID token, add the following claims to the payload:
+# 
+# 1. "auth_time": <timestamp>          # The time the end-user was authenticated
+# 2. "nonce": "<unique-string>"        # A unique value to prevent replay attacks
+# 3. "name": "<user-full-name>"        # Optional profile claim for the user's full name
+# 4. "email": "<user-email-address>"   # Optional profile claim for the user's email
+# 5. "given_name": "<user-first-name>" # Optional profile claim for the user's first name
+# 6. "family_name": "<user-last-name>" # Optional profile claim for the user's last name
+# 
+# Note: The "iss", "sub", "aud", "exp", and "iat" claims are already required for OIDC.
+# Ensure the JWT is signed and that the "nonce" is included in the authentication request.
+
 # JWT payload
 read -r -d '' jwt_payload << EOM
 {

--- a/task_04/jobs-openapi-spec-appolicy.yaml
+++ b/task_04/jobs-openapi-spec-appolicy.yaml
@@ -10,7 +10,7 @@ spec:
     template:
       name: POLICY_TEMPLATE_NGINX_BASE
     open-api-files:
-      - link: https://raw.githubusercontent.com/tmarfil/appworld-2024-nginx-api-gateway-for-k8s/main/task_04/jobs-openapi-spec.yaml
+      - link: https://raw.githubusercontent.com/tmarfil/nginx-api-gateway-for-k8s/refs/heads/main/task_04/jobs-openapi-spec.yaml
     blocking-settings:
       violations:
         - block: true


### PR DESCRIPTION
- Modified `create-signed-jwt.sh` to create OIDC compliant JWTs
- Updated reference to `jobs-openapi-spec.yaml` file in appolicy